### PR TITLE
fixing flutter_riverpod provider working in dart > 2.14.0 and flutter 2.5.0

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,0 +1,1 @@
+C:/Users/kelvi/fvm/versions/stable

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "stable",
+  "flavors": {}
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: 1.0.0-dev.6
+  flutter_riverpod: 1.0.0-dev.11
   
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This will fix the issue in Flutter_riverpod the bug was 
 "When accessing an overridden (scoped) provider in ChangeNotifierProvider._create function, it "ignores" the overridden value."
as seen here   https://github.com/rrousselGit/river_pod/issues/800#issue-1021344634

